### PR TITLE
Shift instead of pop to get `next`

### DIFF
--- a/http/middleware.js
+++ b/http/middleware.js
@@ -106,7 +106,7 @@ var handle = exports.handle = function (handler) {
         var vargs = slice.call(arguments)
         var request = vargs.shift(),
             response = vargs.shift(),
-            next = vargs.pop()
+            next = vargs.shift()
 
         handler.apply(null, [ request ].concat(vargs, [ done ]))
 


### PR DESCRIPTION
Parsed url parameters are appended after the next function, e,g, `req, res, next, id`.